### PR TITLE
Crystal/OAuth

### DIFF
--- a/client/App.scss
+++ b/client/App.scss
@@ -5,7 +5,8 @@ body {
 }
 
 #codesmithImg {
-  width: 27vw;
+  min-width: 200px;
+  max-width: 27.5vw;
   // height: auto;
   // position: absolute;
   // top: 0px;

--- a/client/App.scss
+++ b/client/App.scss
@@ -22,20 +22,14 @@ body {
 .LandingPage {
   // width: 100vw;
   // height: 100vh;
-
   background-color: #020C25;
-
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items:center;
   gap:5vw;
-
   margin-left: auto;
   margin-right: auto;
-
-
-
 
   .LandingText {
     text-align: center;
@@ -53,135 +47,53 @@ body {
 
   .LogInButton {
     cursor: pointer;
-    width: 275px;
+    width: 350px;
     height: 70px;
-    background-image: url('https://i.stack.imgur.com/mKpeu.png');
-    background-size: 265px;
+    background-image: url('https://user-images.githubusercontent.com/9599/61177475-2ddce800-a58b-11e9-9bf6-aa4794a99f2a.png');
+    background-position: center;
+    background-size: cover;
+    // background-size: 265px;
     border-radius: 15px;
-    border: 5px solid rgb(0, 126, 189);
+    // border: 5px solid #000;
+    transition: transform linear 0.3s;
   }
 
   .LogInButton:hover {
-    border: 5px solid  #019be8;
-    box-shadow: -3px 4px 6px  #00314a;
-    transition: 0.3s;
+    // border: 5px solid  #fff;
+    transform: scale(1.005);
   }
 
   .LogInButton:active {
     background-color: #ffbf00;
-}
+  }
 }
 
 .bigger {
   font-size: 250%;
 }
 
-.SetCohort {
-  width: 100vw;
-  height: 120vh;
-  z-index: 1000;
-
+.MainPage {
+  // width: 100vw;
+  // height: 100vh;
   background-color: #020C25;
-
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items:center;
-  gap:5vw;
-
+  gap: 5vw;
   margin-left: auto;
   margin-right: auto;
-  margin-top: 0vh;
+  color: whitesmoke;
+  font-family: Verdana, Tahoma, sans-serif;
 
-  padding: 20px;
-
-
-
-  .SetCohortText {
+  .MainText {
     text-align: center;
     font-family: Verdana, Tahoma, sans-serif;
-    font-size: 25px;
-    color: whitesmoke;
-    width: 70vw;
+    font-size: 3.25em;
   }
 
-  .lineTitle {
-    font-family: Verdana, Tahoma, sans-serif;
-    font-size: 20px;
-    color: whitesmoke;
-  }
-
-  #cohortSelect {
-    padding: 6px;
-    width: 8vw;
-    height: 5vh;
-    margin-bottom: 4vh;
-    margin-right: 30px;
-    border-radius: 8px;
-    font-size: 15px !important;
-  }
-
-  #orgSelect {
-    padding: 10px;
-    width: 16vw;
-    height: 5vh;
-    margin-bottom: 4vh;
-    margin-right: 30px;
-    border-radius: 8px;
-    font-size: 15px !important;
-  }
-
-  #linkedSelect {
-    padding: 10px;
-    width: 13.2vw;
-    height: 5vh;
-    margin-bottom: 4vh;
-    margin-right: 30px;
-    border-radius: 8px;
-    font-size: 15px !important;
-  }
-
-  #cohortNumberSelect {
-    padding: 10px;
-    width: 6vw;
-    height: 5vh;
-    margin-bottom: 4vh;
-    margin-right: 30px;
-    border-radius: 8px;
-    font-size: 15px !important;
-  }
-
-  .SetCohortInput {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-
-    gap: 1vw;
-
-    input {
-      width: 10vw;
-    }
-
-    button {
-      width: 15vw;
-      height: 7vh;
-      border-radius: 15px;
-      color: whitesmoke;
-      background-color: #008dd3;
-      border: #008dd3;
-      font-family: Verdana, Tahoma, sans-serif;
-      font-weight: 500;
-    }
-      button:hover {
-    background-color: #009fee;
-    transition: 0.3s;
-  }
-
-  button:active {
-    background-color: #0180c0;
-}
+  textarea {
+    padding: 0.5em 1em;
   }
 }
 

--- a/client/pages/App.jsx
+++ b/client/pages/App.jsx
@@ -20,6 +20,8 @@ function App() {
 
   // code adapted from MDN: https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
   // ?. explained here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining
+  console.log('hello!')
+  if (document.cookie) console.log('document.cookie:', document.cookie);
   const getCookie = (cookie) => {
     return document.cookie
       .split('; ')
@@ -30,16 +32,17 @@ function App() {
   // on page load, check authentication status. the [] at the end signals we will never re-check this session.
   // i.e. we're not subscribing this useEffect hook to any other changes in state.
   useEffect(() => {
-    if (getCookie('sessionID')) {
-    console.log('found a session cookie. validating...')
-    fetch('http://localhost:3000/verifyuser', {
-      credentials: 'same-origin',
-    })
-    .then(res => {
-      if (res.status === 200) changeAuthenticated(true);
-      else document.cookie = 'SessionID=; expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure'
-    });
-    }
+    // if (getCookie('sessionID')) {
+    //   console.log('found a session cookie. validating...')
+      fetch('/verifyuser', {
+        credentials: 'same-origin',
+      })
+      .then(res => {
+        console.log('res inside fetch call for /verifyuser: ', res);
+        // if (res.status === 200) changeAuthenticated(true);
+        // else document.cookie = 'SessionID=; expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure'
+      });
+    // }
   }, []);
 
   return (

--- a/client/pages/LandingPage.jsx
+++ b/client/pages/LandingPage.jsx
@@ -8,9 +8,10 @@ export const LandingPage = (props) => {
 
   //Redirect user to LinkedIn OAuth then if successful set authenticated to true
   async function logIn() {
+    const CLIENT_ID = 'Iv1.17f49f5c8005c3c4';
     // INSERT GOOGLE OAUTH REQUEST HERE.
     //parent.open(`https://www.linkedin.com/oauth/v2/authorization/?response_type=code&client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&state="A9Sd.udf8-d1"&scope=${SCOPE}`)
-
+    parent.open(`https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}`)
     //result.isInSystem === true => 
     props.changeAuthenticated(true);
   }
@@ -20,6 +21,9 @@ export const LandingPage = (props) => {
       <img id='codesmithImg' src="https://miro.medium.com/max/1200/1*aqCqaO8ALzYczUHe_3g3Gw.jpeg" alt="Codesmith Logo"></img>
       <span className="LandingText">Welcome to <br /> Codesmith's Answering Service<br /></span>
       <button className="LogInButton" onClick={() => logIn()}>Sign in with GitHub</button>
+      {/* <h1>Answer-ing</h1> */}
+      {/* <button className='consent' onClick={() => logIn()}>Register with GitHub</button> */}
+      {/* <button className='consent' onClick={() => parent.open(`https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}`)}>Register with GitHub</button> */}
     </div>
   );
 };

--- a/client/pages/LandingPage.jsx
+++ b/client/pages/LandingPage.jsx
@@ -20,7 +20,7 @@ export const LandingPage = (props) => {
     <div className="LandingPage">
       <img id='codesmithImg' src="https://miro.medium.com/max/1200/1*aqCqaO8ALzYczUHe_3g3Gw.jpeg" alt="Codesmith Logo"></img>
       <span className="LandingText">Welcome to <br /> Codesmith's Answering Service<br /></span>
-      <button className="LogInButton" onClick={() => logIn()}>Sign in with GitHub</button>
+      <button className="LogInButton" onClick={() => logIn()}></button>
       {/* <h1>Answer-ing</h1> */}
       {/* <button className='consent' onClick={() => logIn()}>Register with GitHub</button> */}
       {/* <button className='consent' onClick={() => parent.open(`https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}`)}>Register with GitHub</button> */}

--- a/client/pages/MainPage.jsx
+++ b/client/pages/MainPage.jsx
@@ -15,8 +15,8 @@ function MainPage(props) {
   // this is usually done with query params (?search=""&tag=""&role="", etc.)
 
   return (
-    <div>
-      <h1>you have hit the main page. congrats you are a baller!</h1>
+    <div className="MainPage">
+      <span className="MainText">Answer.ing<br /></span>
       <NavbarContainer />
       <PostQuestion />
       {/* {questions} */}

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -1,0 +1,134 @@
+// const express = require('express');
+// const server = express();
+const db = require('../models/dbModel.js');
+const fetch = require('node-fetch');
+const request = require('superagent');
+// const axios = require('axios');
+// require('dotenv').config();
+// const CLIENT_ID = 'b9cb6a79d6b5b3655653';
+const CLIENT_ID = 'Iv1.17f49f5c8005c3c4';
+// const CLIENT_SECRET = 'b44551fa00c02ac80a15bd2ffebabee5052513ce';
+const CLIENT_SECRET = '675442a98307f2fdb4e42870358cce13785b6768';
+// axios.get('some link').then(res => res.data)
+
+const authController = {};
+
+authController.getToken = (req, res, next) => {
+  console.log('hello from authController.getToken!');
+  const { code } = req.query;
+  console.log('code:', code)
+
+  // if (!code) {
+  //   console.log('code doesnt exist');
+  //   return next({error: 'error in getToken: auth code not received'})
+  // } else {
+  //   res.locals.code = code;
+  //   return next();
+  // }
+
+
+  request
+    .post('https://github.com/login/oauth/access_token')
+    .send({
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+      code: code,
+      scope: 'user:email',
+    })
+    .set('Accept', 'application/json')
+    .then(function(result) {
+      const data = result.body;
+      res.locals.data = data;
+      res.locals.accessToken = data.access_token;
+      // data should look like:
+      // { access_token, token_type, scope }
+      console.log('data', res.locals.data)
+      return next();
+    })
+}
+
+authController.getUser = async (req, res, next) => {
+  console.log('token:', res.locals.accessToken);
+  // try {
+  //   const result = await fetch(
+  //     'https://api.github.com/user', {
+  //       headers: {
+  //         Authorization: 'Bearer ' + res.locals.accessToken
+  //         // Authorization: 'Bearer ' + req.cookies.access_token
+  //       }
+  //     }
+  //   );
+  //   const parsedResult = await result.json();
+  //   // res.locals.name = parsedResult.localizedFirstName + ' ' + parsedResult.localizedLastName;
+  //   // console.log('me API call result');
+  //   console.log('result:');
+  //   console.log(parsedResult);
+  //   return next();
+  // }
+  // catch(err) {
+  //   return next(err);
+  // }
+
+  request
+    .get('https://api.github.com/user')
+    .set({ 
+      'Authorization': `Bearer ${res.locals.accessToken}`,
+      'User-Agent': 'Answer.Ing',
+      'Accept': "application/vnd.github.v3+json" 
+    })
+    .then(function(result) {
+      console.log('in result');
+      const user = result.body
+      // console.log(user)
+      res.locals.user = user;
+      console.log('user', res.locals.user)
+      return next();
+    })
+}
+
+
+  
+// authController.getTokenOLD = (req, res, next) => {
+//   const { code } = req.query;
+
+//   if (!code) {
+//     return res.send('error in getToken: auth code not received');
+//   }
+
+//   request
+//     .post('https://github.com/login/oauth/access_token')
+//     .send({
+//       client_id: CLIENT_ID,
+//       client_secret: CLIENT_SECRET,
+//       code: code,
+//       scope: 'user:email',
+//     })
+//     .set('Accept', 'application/json')
+//     .then(function(result) {
+//       const data = result.body;
+//       res.locals.data = data;
+//       res.locals.accessToken = data.access_token;
+//       // data should look like:
+//       // { access_token, token_type, scope }
+//       console.log('data', res.locals.data)
+//       return next();
+//     })
+// }
+
+// authController.getUserOLD = (req, res, next) => {
+//   console.log('token:', res.locals.accessToken)
+//   request
+//     .get('https://api.github.com/user')
+//     .set({ 'Authorization': `Bearer ${res.locals.accessToken}`, 
+//            'Accept': "application/vnd.github.v3+json" })
+//     .then(function(result) {
+//       console.log('in result');
+//       const user = result.body
+//       // console.log(user)
+//       res.locals.user = user;
+//       console.log('user', res.locals.user)
+//       return next();
+//     })
+// }
+
+module.exports = authController;

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -40,34 +40,14 @@ authController.getToken = (req, res, next) => {
       const data = result.body;
       res.locals.data = data;
       res.locals.accessToken = data.access_token;
-      // data should look like:
-      // { access_token, token_type, scope }
-      console.log('data', res.locals.data)
+
+      console.log('data', res.locals.data);
       return next();
     })
 }
 
 authController.getUser = async (req, res, next) => {
   console.log('token:', res.locals.accessToken);
-  // try {
-  //   const result = await fetch(
-  //     'https://api.github.com/user', {
-  //       headers: {
-  //         Authorization: 'Bearer ' + res.locals.accessToken
-  //         // Authorization: 'Bearer ' + req.cookies.access_token
-  //       }
-  //     }
-  //   );
-  //   const parsedResult = await result.json();
-  //   // res.locals.name = parsedResult.localizedFirstName + ' ' + parsedResult.localizedLastName;
-  //   // console.log('me API call result');
-  //   console.log('result:');
-  //   console.log(parsedResult);
-  //   return next();
-  // }
-  // catch(err) {
-  //   return next(err);
-  // }
 
   request
     .get('https://api.github.com/user')
@@ -78,57 +58,12 @@ authController.getUser = async (req, res, next) => {
     })
     .then(function(result) {
       console.log('in result');
-      const user = result.body
-      // console.log(user)
+      const user = result.body;
       res.locals.user = user;
-      console.log('user', res.locals.user)
+      console.log('user', res.locals.user);
       return next();
     })
 }
 
-
-  
-// authController.getTokenOLD = (req, res, next) => {
-//   const { code } = req.query;
-
-//   if (!code) {
-//     return res.send('error in getToken: auth code not received');
-//   }
-
-//   request
-//     .post('https://github.com/login/oauth/access_token')
-//     .send({
-//       client_id: CLIENT_ID,
-//       client_secret: CLIENT_SECRET,
-//       code: code,
-//       scope: 'user:email',
-//     })
-//     .set('Accept', 'application/json')
-//     .then(function(result) {
-//       const data = result.body;
-//       res.locals.data = data;
-//       res.locals.accessToken = data.access_token;
-//       // data should look like:
-//       // { access_token, token_type, scope }
-//       console.log('data', res.locals.data)
-//       return next();
-//     })
-// }
-
-// authController.getUserOLD = (req, res, next) => {
-//   console.log('token:', res.locals.accessToken)
-//   request
-//     .get('https://api.github.com/user')
-//     .set({ 'Authorization': `Bearer ${res.locals.accessToken}`, 
-//            'Accept': "application/vnd.github.v3+json" })
-//     .then(function(result) {
-//       console.log('in result');
-//       const user = result.body
-//       // console.log(user)
-//       res.locals.user = user;
-//       console.log('user', res.locals.user)
-//       return next();
-//     })
-// }
 
 module.exports = authController;

--- a/server/routes/authRouter.js
+++ b/server/routes/authRouter.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const authController = require('../controllers/authController.js');
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  return res.status(200).send('hello world!');
+})
+
+router.get('/signin', authController.getToken, authController.getUser, (req, res) => {
+  console.log('done!');
+  return res.status(200).send(res.locals.data);
+})
+
+module.exports = router;

--- a/server/routes/verifyRouter.js
+++ b/server/routes/verifyRouter.js
@@ -1,0 +1,15 @@
+const { Router } = require('express');
+const authController = require('../controllers/authController.js');
+// const { exchangeCode, callMeAPI,  callEmailAPI,  verifyUserExists, createUser, userComplete} = require('../controllers/oauthController');
+
+const router = Router();
+
+// localhost:8080/verifyuser
+router.get('/', authController.getToken, authController.getUser, (req, res) => {
+  // return res.redirect('/');
+  console.log('hello from final func in /verifyuser GET request');
+  return res.sendStatus(200);
+  //.redirect('/');
+});
+
+module.exports = router;

--- a/server/routes/verifyRouter.js
+++ b/server/routes/verifyRouter.js
@@ -6,10 +6,10 @@ const router = Router();
 
 // localhost:8080/verifyuser
 router.get('/', authController.getToken, authController.getUser, (req, res) => {
-  // return res.redirect('/');
-  console.log('hello from final func in /verifyuser GET request');
-  return res.sendStatus(200);
-  //.redirect('/');
+  console.log('Finished fetching user data from GitHub!');
+  console.log(res.locals.user)
+  console.log('res.locals.user')
+  return res.status(200).json(res.locals.user);
 });
 
 module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -6,11 +6,18 @@ const userRouter = require('./routes/userRouter');
 
 const server = express();
 const PORT = process.env.PORT || 3000; // heroku port || localhost
+const authRouter = require('./routes/authRouter');
+const verifyRouter = require('./routes/verifyRouter');
 
 server.use(express.json());
 server.use(express.urlencoded({ extended: true }));
 server.use(cookieParser()); // Parses cookies sent with the forms from the frontend
 server.use(cors());
+
+server.use('/login', authRouter);
+server.use('/', verifyRouter);
+
+
 // server.use('/public', express.static(path.join(__dirname, '..', 'public')));
 
 // server.get('/', (req, res, next) => {
@@ -18,6 +25,9 @@ server.use(cors());
 //   // return res.status(200).send('hello world');
 // });
 
+// server.get('/*', (req, res) => {
+//   return res.status(200).redirect('/');
+// });
 server.use('/', userRouter);
 
 // catch-all route handler for any requests to an unknown route
@@ -40,3 +50,6 @@ server.use((err, req, res, next) => {
 server.listen(PORT, () => {
 	console.log('Server is listening on port ' + PORT);
 })
+
+// might not need this part
+module.exports = server;

--- a/server/server.js
+++ b/server/server.js
@@ -6,7 +6,7 @@ const userRouter = require('./routes/userRouter');
 
 const server = express();
 const PORT = process.env.PORT || 3000; // heroku port || localhost
-const authRouter = require('./routes/authRouter');
+// const authRouter = require('./routes/authRouter');
 const verifyRouter = require('./routes/verifyRouter');
 
 server.use(express.json());
@@ -14,21 +14,9 @@ server.use(express.urlencoded({ extended: true }));
 server.use(cookieParser()); // Parses cookies sent with the forms from the frontend
 server.use(cors());
 
-server.use('/login', authRouter);
+// server.use('/login', authRouter);
 server.use('/', verifyRouter);
-
-
-// server.use('/public', express.static(path.join(__dirname, '..', 'public')));
-
-// server.get('/', (req, res, next) => {
-//   return res.status(200).sendFile(path.resolve(__dirname, '../public/index.html'));
-//   // return res.status(200).send('hello world');
-// });
-
-// server.get('/*', (req, res) => {
-//   return res.status(200).redirect('/');
-// });
-server.use('/', userRouter);
+// server.use('/', userRouter);
 
 // catch-all route handler for any requests to an unknown route
 server.use('*', (req, res) => res.sendStatus(404));
@@ -49,7 +37,4 @@ server.use((err, req, res, next) => {
 
 server.listen(PORT, () => {
 	console.log('Server is listening on port ' + PORT);
-})
-
-// might not need this part
-module.exports = server;
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,9 +89,35 @@ module.exports = {
     compress: true,
     hot: true,
     proxy: {
-      '/api': {
-        target: 'http://localhost:3000',
+      '/**': {
+        target: 'http://localhost:3000/',
         secure: false,
+        changeOrigin: true,
+      },
+      '/assets/**': {
+        target: 'http://localhost:3000/',
+        secure: false,
+        changeOrigin: true,
+      },
+      '/login/**': {
+        target: 'http://localhost:3000/',
+        secure: false,
+        changeOrigin: true,
+      },
+      '/login': {
+        target: 'http://localhost:3000/',
+        secure: false,
+        changeOrigin: true,
+      },
+      '/verifyuser': {
+        target: 'http://localhost:3000/verifyuser',
+        secure: false,
+        changeOrigin: true,
+      },
+      '/verifyuser**': {
+        target: 'http://localhost:3000/verifyuser',
+        secure: false,
+        changeOrigin: true,
       },
     },
   },


### PR DESCRIPTION
Despite the branch name, I didn't actually make any strides with the database functionality. However, I was able to get GitHub OAuth to return personal GitHub user data in both the terminal and `localhost:3000`. I wasn't sure how to close the `localhost:3000` tab once we received the data, and I'm not even sure why it opens up a new tab in the first place. But in the original tab, `localhost:8080` is re-routed to display the main dashboard after authenticating. 

**New to-dos:**
- Aside from changing the `isAuthenticated` state to '`true`', there is no actual frontend authentication using cookies, I forgot to set the cookies on the backend, so someone can do that if they wish. 
- Add some of the GitHub user credentials to the database
- Flesh out more `dbController`/`userController` functionality
- Improve the frontend styling and UI (I'd be happy to assist with this one!)
- Move the (currently exposed) GitHub OAuth App Keys to the .env file
- Figure out how to fix `localhost:3000` awkwardly remaining, post-authentication

By the way, if anyone was wondering what the GitHub OAuth fix was, it was adding a [`"User-Agent" header`](https://www.codecademy.com/forum_questions/5182f2a05307399592000915) to the `authController.getUser` GET request. This was a hard one - I eventually figured it out when I finally decided to read the gigantic error log! Also, I added more proxies to the webpack config and created my own GitHub OAuth keys so I could set the callback URL to '`http://localhost:3000/`'. The OAuth requests to the server is made at the '`/verifyuser`' endpoint I created. The pathing was an **_extremely delicate and opinionated_** process, and the OAuth breaks the moment anything related to the pathing changes.